### PR TITLE
note feed aggregator in output

### DIFF
--- a/transitfeeds.py
+++ b/transitfeeds.py
@@ -1,10 +1,7 @@
 from bs4 import BeautifulSoup
-import urllib.parse
 from urllib.error import HTTPError
-import yaml
 
 from cache import curl_cached
-from utils import extract_urls
 
 LOCATION = "67-california-usa"
 ROOT = "https://transitfeeds.com"
@@ -18,11 +15,11 @@ def resolve_url(url):
     raise ValueError("Not a transit feed url: {url}")
 
 
-def get_transitfeeds_urls(domains):
+def get_transitfeeds_urls():
     page_urls = []
     provider_urls = []
     feed_urls = []
-    result_urls = set()
+    results = []
 
     html = curl_cached(f"{ROOT}/l/{LOCATION}")
     soup = BeautifulSoup(html, "html.parser")
@@ -54,19 +51,5 @@ def get_transitfeeds_urls(domains):
             url = a["href"]
             if url.startswith("/") or url.startswith(ROOT):
                 continue
-            domain = urllib.parse.urlparse(url).netloc
-            if domain in domains:
-                result_urls.add(url)
-    return result_urls
-
-
-if __name__ == "__main__":
-    with open("agencies.yml", "r") as f:
-        agencies_obj = yaml.load(f, Loader=yaml.SafeLoader)
-    urls = extract_urls(agencies_obj, dict_prefix="gtfs_rt")
-    domains = set()
-    for url in urls:
-        domains.add(urllib.parse.urlparse(url).netloc)
-    for url in get_transitfeeds_urls(domains):
-        if url in urls:
-            print(url)
+            results.append((feed_url, url))
+    return results

--- a/utils.py
+++ b/utils.py
@@ -7,25 +7,3 @@ def url_split(url):
     if url_obj.query:
         return url_obj.netloc, f"{url_obj.path}?{url_obj.query}"
     return url_obj.netloc, url_obj.path
-
-
-def extract_urls(dict_or_list):
-    """
-    Recurse obj and return any urls
-    """
-    urls = []
-
-    def match(key, value):
-        return isinstance(value, (dict, list, str))
-
-    def extract(obj):
-        if isinstance(obj, dict):
-            obj = [value for key, value in obj.items() if match(key, value)]
-        if isinstance(obj, str):
-            if obj.startswith("http"):
-                urls.append(obj)
-        elif isinstance(obj, list):
-            [extract(i) for i in obj]
-
-    extract(dict_or_list)
-    return urls


### PR DESCRIPTION
This fixes #5 and changes the json to match the format in the issue.

``` bash
$ python feed_checker.py --url http://example.com --output results.json
Found 0/1 urls were found
Results saved to results.json
$ cat results.json
{
    "http://example.com": {
        "transitfeeds": {
            "status": "missing"
        },
        "transitland": {
            "status": "missing"
        }
    }
}
```